### PR TITLE
Fetching an empty collection should not yield an exception

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,14 @@
 # BeenPwned.Api
 .NET Wrapper library for the [haveibeenpwned.com API](https://haveibeenpwned.com/api/)
 
+## Platform support
+
+|Platform|Version|
+| ------------------- | :----------:|
+|.NET|4.5 & 4.6|
+|.NET Standard|1.3|
+|PCL|Profile 111|
+
 ## Documentation
     /// <summary>
     /// A client which contains all functionality to communicate with the public haveibeenpwned.com API.

--- a/src/BeenPwned.Api/BeenPwnedClient.cs
+++ b/src/BeenPwned.Api/BeenPwnedClient.cs
@@ -31,7 +31,7 @@ namespace BeenPwned.Api
 
             var endpointUrl = Utilities.BuildQueryString("breaches", queryValues);
 
-            return await _requestExecuter.GetResultAsync<IEnumerable<Breach>>(endpointUrl);
+            return await _requestExecuter.GetCollectionAsync<Breach>(endpointUrl);
         }
 
         public async Task<IEnumerable<Breach>> GetBreachesForAccount(string account, string domain ="", bool truncateResponse = true, bool includeUnverified = false)
@@ -50,7 +50,7 @@ namespace BeenPwned.Api
 
             var endpointUrl = Utilities.BuildQueryString($"breachedaccount/{account}", queryValues);
 
-            return await _requestExecuter.GetResultAsync<IEnumerable<Breach>>(endpointUrl);
+            return await _requestExecuter.GetCollectionAsync<Breach>(endpointUrl);
         }
 
         public async Task<IEnumerable<Paste>> GetPastesForAccount(string account)
@@ -61,12 +61,12 @@ namespace BeenPwned.Api
             if (!Utilities.IsValidEmailaddress(account))
                 throw new ArgumentException("Account it not a (valid) emailaddress", nameof(account));
 
-            return await _requestExecuter.GetResultAsync<IEnumerable<Paste>>($"pasteaccount/{account}");
+            return await _requestExecuter.GetCollectionAsync<Paste>($"pasteaccount/{account}");
         }
 
         public async Task<IEnumerable<string>> GetAllDataClasses()
         {
-            return await _requestExecuter.GetResultAsync<IEnumerable<string>>("dataclasses");
+            return await _requestExecuter.GetCollectionAsync<string>("dataclasses");
         }
         
         public async Task<bool> GetPwnedPassword(string password, bool originalPasswordIsAHash = false,

--- a/src/BeenPwned.Api/Internals/IRequestExecuter.cs
+++ b/src/BeenPwned.Api/Internals/IRequestExecuter.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Net.Http;
 using System.Threading.Tasks;
 
@@ -6,7 +7,7 @@ namespace BeenPwned.Api.Internals
 {
     internal interface IRequestExecuter : IDisposable
     {
-        Task<T> GetResultAsync<T>(string endpoint) where T : class;
+        Task<IEnumerable<T>> GetCollectionAsync<T>(string endpoint) where T : class;
         Task<HttpResponseMessage> GetAsync(string endpointUrl);
         Task<HttpResponseMessage> PostAsync(string endpointUrl, FormUrlEncodedContent formUrlEncodedContent);
     }

--- a/src/BeenPwned.Api/Internals/RequestExecuter.cs
+++ b/src/BeenPwned.Api/Internals/RequestExecuter.cs
@@ -1,4 +1,6 @@
 ﻿using System;
+using System.Collections.Generic;
+using System.Linq;
 using System.Net;
 using System.Net.Http;
 using System.Net.Http.Headers;
@@ -34,7 +36,7 @@ namespace BeenPwned.Api.Internals
             _httpClient.Dispose();
         }
 
-        public async Task<T> GetResultAsync<T>(string endpoint) where T : class
+        public async Task<IEnumerable<T>> GetCollectionAsync<T>(string endpoint) where T : class
         {
             var response = await _httpClient.GetAsync(endpoint);
 
@@ -47,7 +49,7 @@ namespace BeenPwned.Api.Internals
                 case 403:
                     throw new BeenPwnedUnavailableException("Access denied");
                 case 404:
-                    throw new BeenPwnedUnavailableException("Not found");
+                    return Enumerable.Empty<T>();
                 case 429:
                     throw new BeenPwnedUnavailableException("Too many requests");
                 default:
@@ -55,7 +57,7 @@ namespace BeenPwned.Api.Internals
             }
 
             var stringResult = await response.Content.ReadAsStringAsync();
-            return JsonConvert.DeserializeObject<T>(stringResult);
+            return JsonConvert.DeserializeObject<IEnumerable<T>>(stringResult);
         }
 
         public Task<HttpResponseMessage> GetAsync(string endpointUrl)

--- a/src/BeenPwned.Api/Internals/RequestExecuter.cs
+++ b/src/BeenPwned.Api/Internals/RequestExecuter.cs
@@ -47,13 +47,13 @@ namespace BeenPwned.Api.Internals
                 case 400:
                     throw new BeenPwnedUnavailableException("Invalid request");
                 case 403:
-                    throw new BeenPwnedUnavailableException("Access denied");
+                    throw new BeenPwnedUnavailableException("Access denied: probably no user-agent is specified for the request.");
                 case 404:
                     return Enumerable.Empty<T>();
                 case 429:
-                    throw new BeenPwnedUnavailableException("Too many requests");
+                    throw new BeenPwnedUnavailableException("Too many requests: rate-limit exceeded. Please try again in a second.");
                 default:
-                    throw new BeenPwnedUnavailableException("Unkown error");
+                    throw new BeenPwnedUnavailableException($"Unknown error. Statuscode {response.StatusCode}, message: {response.ReasonPhrase}");
             }
 
             var stringResult = await response.Content.ReadAsStringAsync();


### PR DESCRIPTION
GetResultAsync -> GetCollectionAsync to underline that this method is for fetching a collection, which makes it reasonable to return an empty enumerable for a 404 instead of throwing

Fixes jfversluis/BeenPwned.Api#6